### PR TITLE
Add feature to change first day of the week

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,13 +52,14 @@ Lightweight Calendar View can be easily customized by setting properties in the 
 
 The following properties are available:
 
-| property name              | type              | description                           |
-| -------------------------- | ----------------- | ------------------------------------- |
-| app:lcv_weekDayTextSize    | dimension         | The text size of weekdays             |
-| app:lcv_dayTextSize        | dimension         | The text size of days                 |
-| app:lcv_textColor          | color or resource | The text color of weekdays and days   |
-| app:lcv_selectionColor     | color or resource | The background color of selections    |
-| app:lcv_accentColor        | color or resource | The color of accents                  |
+| property name              | type              | description                                                         |
+| -------------------------- | ----------------- | ------------------------------------------------------------------- |
+| app:lcv_weekDayTextSize    | dimension         | The text size of weekdays                                           |
+| app:lcv_dayTextSize        | dimension         | The text size of days                                               |
+| app:lcv_textColor          | color or resource | The text color of weekdays and days                                 |
+| app:lcv_selectionColor     | color or resource | The background color of selections                                  |
+| app:lcv_accentColor        | color or resource | The color of accents                                                |
+| app:lcv_firstDayOfWeek     | integer           | The first day of the week (0 = Sunday, 1 = Monday, ..., 6 = Friday) |
 
 The customizations of text colors of selected days or today are done by setting &lt;selector /&gt; color resources to `app:lcv_textColor`, `app:lcv_selectionColor`, or `app:lcv_accentColor` with the following resource files for example.
 

--- a/library/src/main/kotlin/jp/co/recruit_mp/android/lightcalendarview/CalendarSettings.kt
+++ b/library/src/main/kotlin/jp/co/recruit_mp/android/lightcalendarview/CalendarSettings.kt
@@ -32,6 +32,9 @@ class CalendarSettings(private val context: Context) : ObservableSettings() {
     val dayView = DayView(observer)
     var firstDayOfWeek: WeekDay = WeekDay.SUNDAY
 
+    internal val weekDayOffset: Int
+        get() = WeekDay.values().indexOf(firstDayOfWeek)
+
     /**
      * Settings for {@link jp.co.recruit_mp.android.lightcalendarview.WeekDayView}
      */

--- a/library/src/main/kotlin/jp/co/recruit_mp/android/lightcalendarview/CalendarSettings.kt
+++ b/library/src/main/kotlin/jp/co/recruit_mp/android/lightcalendarview/CalendarSettings.kt
@@ -30,6 +30,7 @@ class CalendarSettings(private val context: Context) : ObservableSettings() {
 
     val weekDayView = WeekDayView(observer)
     val dayView = DayView(observer)
+    var firstDayOfWeek: WeekDay = WeekDay.SUNDAY
 
     /**
      * Settings for {@link jp.co.recruit_mp.android.lightcalendarview.WeekDayView}

--- a/library/src/main/kotlin/jp/co/recruit_mp/android/lightcalendarview/CalendarSettings.kt
+++ b/library/src/main/kotlin/jp/co/recruit_mp/android/lightcalendarview/CalendarSettings.kt
@@ -28,11 +28,15 @@ class CalendarSettings(private val context: Context) : ObservableSettings() {
 
     private val observer = Observer { observable, any -> notifyObservers(any) }
 
+    // settings for WeekDayView
     val weekDayView = WeekDayView(observer)
-    val dayView = DayView(observer)
-    var firstDayOfWeek: WeekDay = WeekDay.SUNDAY
 
-    internal val weekDayOffset: Int
+    // settings for DayView
+    val dayView = DayView(observer)
+
+    // settings for DayLayout and WeekDayLayout: first day of the week
+    var firstDayOfWeek: WeekDay = WeekDay.SUNDAY
+    val dayOfWeekOffset: Int
         get() = WeekDay.values().indexOf(firstDayOfWeek)
 
     /**

--- a/library/src/main/kotlin/jp/co/recruit_mp/android/lightcalendarview/DayLayout.kt
+++ b/library/src/main/kotlin/jp/co/recruit_mp/android/lightcalendarview/DayLayout.kt
@@ -39,9 +39,10 @@ class DayLayout(context: Context, settings: CalendarSettings, var month: Date) :
     internal var selectedDayView: DayView? = null
 
     internal var callback: Callback? = null
-    var firstDate: Date
-    val thisYear: Int
-    val thisMonth: Int
+    private var firstDate: Calendar = Calendar.getInstance()
+    private var weekDayOffset: Int = -1
+    private val thisYear: Int
+    private val thisMonth: Int
 
     init {
         val cal: Calendar = Calendar.getInstance().apply {
@@ -51,10 +52,50 @@ class DayLayout(context: Context, settings: CalendarSettings, var month: Date) :
         thisYear = cal[Calendar.YEAR]
         thisMonth = cal[Calendar.MONTH]
 
-        // calculate the date of the top-left cell
-        val weekDayOffset = WeekDay.values().indexOf(settings.firstDayOfWeek)
-        cal.add(Calendar.DAY_OF_YEAR, -cal[Calendar.DAY_OF_WEEK] + weekDayOffset + 1)
-        firstDate = cal.time
+        // update the layout
+        updateLayout()
+
+        // 今日を選択
+        setSelectedDay(Date())
+    }
+
+    private val observer = Observer { observable, any ->
+        updateLayout()
+    }
+
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+        settings.addObserver(observer)
+    }
+
+    override fun onDetachedFromWindow() {
+        settings.deleteObserver(observer)
+        super.onDetachedFromWindow()
+    }
+
+    private fun updateLayout() {
+        if (weekDayOffset != settings.weekDayOffset) {
+            weekDayOffset = settings.weekDayOffset
+
+            val cal: Calendar = Calendar.getInstance().apply {
+                time = month
+                set(Calendar.DAY_OF_MONTH, 1)
+            }
+
+            // calculate the date of top-left cell
+            cal.add(Calendar.DAY_OF_YEAR, -cal[Calendar.DAY_OF_WEEK] + weekDayOffset + 1)
+            firstDate = cal
+
+            // remove all children
+            removeAllViews()
+
+            // populate children
+            populateViews()
+        }
+    }
+
+    private fun populateViews() {
+        val cal = firstDate
 
         // 7 x 6 マスの DayView を追加する
         (0..rowNum - 1).forEach {
@@ -70,9 +111,6 @@ class DayLayout(context: Context, settings: CalendarSettings, var month: Date) :
                 cal.add(Calendar.DAY_OF_YEAR, 1)
             }
         }
-
-        // 今日を選択
-        setSelectedDay(Date())
     }
 
     private fun instantiateDayView(cal: Calendar): DayView = DayView(context, settings, cal).apply {
@@ -109,7 +147,7 @@ class DayLayout(context: Context, settings: CalendarSettings, var month: Date) :
     /**
      * 日付に対応する {@link DayView} を返す
      */
-    fun getDayView(date: Date): DayView? = childList.getOrNull(date.daysAfter(firstDate).toInt()) as? DayView
+    fun getDayView(date: Date): DayView? = childList.getOrNull(date.daysAfter(firstDate.time).toInt()) as? DayView
 
     interface Callback {
         fun onDateSelected(date: Date)

--- a/library/src/main/kotlin/jp/co/recruit_mp/android/lightcalendarview/DayLayout.kt
+++ b/library/src/main/kotlin/jp/co/recruit_mp/android/lightcalendarview/DayLayout.kt
@@ -51,8 +51,9 @@ class DayLayout(context: Context, settings: CalendarSettings, var month: Date) :
         thisYear = cal[Calendar.YEAR]
         thisMonth = cal[Calendar.MONTH]
 
-        // 左上セルの日付を計算
-        cal.add(Calendar.DAY_OF_YEAR, -cal[Calendar.DAY_OF_WEEK] + 1)
+        // calculate the date of the top-left cell
+        val weekDayOffset = WeekDay.values().indexOf(settings.firstDayOfWeek)
+        cal.add(Calendar.DAY_OF_YEAR, -cal[Calendar.DAY_OF_WEEK] + weekDayOffset + 1)
         firstDate = cal.time
 
         // 7 x 6 マスの DayView を追加する

--- a/library/src/main/kotlin/jp/co/recruit_mp/android/lightcalendarview/DayLayout.kt
+++ b/library/src/main/kotlin/jp/co/recruit_mp/android/lightcalendarview/DayLayout.kt
@@ -95,7 +95,7 @@ class DayLayout(context: Context, settings: CalendarSettings, var month: Date) :
     }
 
     private fun populateViews() {
-        val cal = firstDate
+        val cal = firstDate.clone() as Calendar
 
         // 7 x 6 マスの DayView を追加する
         (0..rowNum - 1).forEach {

--- a/library/src/main/kotlin/jp/co/recruit_mp/android/lightcalendarview/DayLayout.kt
+++ b/library/src/main/kotlin/jp/co/recruit_mp/android/lightcalendarview/DayLayout.kt
@@ -40,7 +40,7 @@ class DayLayout(context: Context, settings: CalendarSettings, var month: Date) :
 
     internal var callback: Callback? = null
     private var firstDate: Calendar = Calendar.getInstance()
-    private var weekDayOffset: Int = -1
+    private var dayOfWeekOffset: Int = -1
     private val thisYear: Int
     private val thisMonth: Int
 
@@ -74,16 +74,15 @@ class DayLayout(context: Context, settings: CalendarSettings, var month: Date) :
     }
 
     private fun updateLayout() {
-        if (weekDayOffset != settings.weekDayOffset) {
-            weekDayOffset = settings.weekDayOffset
+        if (dayOfWeekOffset != settings.dayOfWeekOffset) {
+            dayOfWeekOffset = settings.dayOfWeekOffset
 
+            // calculate the date of top-left cell
             val cal: Calendar = Calendar.getInstance().apply {
                 time = month
                 set(Calendar.DAY_OF_MONTH, 1)
+                add(Calendar.DAY_OF_YEAR, -this[Calendar.DAY_OF_WEEK] + dayOfWeekOffset + 1)
             }
-
-            // calculate the date of top-left cell
-            cal.add(Calendar.DAY_OF_YEAR, -cal[Calendar.DAY_OF_WEEK] + weekDayOffset + 1)
             firstDate = cal
 
             // remove all children

--- a/library/src/main/kotlin/jp/co/recruit_mp/android/lightcalendarview/LightCalendarView.kt
+++ b/library/src/main/kotlin/jp/co/recruit_mp/android/lightcalendarview/LightCalendarView.kt
@@ -216,17 +216,17 @@ class LightCalendarView(context: Context, attrs: AttributeSet? = null, defStyleA
     }
 
     /**
-     * Sets the first day of week
+     * First day of the week (e.g. Sunday, Monday, ...)
      */
-    fun setFirstDayOfWeek(weekDay: WeekDay) {
-        settings.apply {
-            firstDayOfWeek = weekDay
-            notifySettingsChanged()
+    var firstDayOfWeek: WeekDay
+        get() = settings.firstDayOfWeek
+        set(value) {
+            settings.firstDayOfWeek = value
+            settings.notifySettingsChanged()
         }
-    }
 
     private fun setFirstDayOfWeek(n: Int) {
-        setFirstDayOfWeek(WeekDay.fromOrdinal(n))
+        firstDayOfWeek = WeekDay.fromOrdinal(n)
     }
 
     private inner class Adapter() : PagerAdapter() {

--- a/library/src/main/kotlin/jp/co/recruit_mp/android/lightcalendarview/LightCalendarView.kt
+++ b/library/src/main/kotlin/jp/co/recruit_mp/android/lightcalendarview/LightCalendarView.kt
@@ -83,6 +83,7 @@ class LightCalendarView(context: Context, attrs: AttributeSet? = null, defStyleA
                 R.styleable.LightCalendarView_lcv_textColor -> setTextColor(a.getColorStateList(attr))
                 R.styleable.LightCalendarView_lcv_selectionColor -> setSelectionColor(a.getColorStateList(attr))
                 R.styleable.LightCalendarView_lcv_accentColor -> setAccentColor(a.getColorStateList(attr))
+                R.styleable.LightCalendarView_lcv_firstDayOfWeek -> setFirstDayOfWeek(a.getInt(attr, 0))
             }
         }
         a.recycle()
@@ -212,6 +213,20 @@ class LightCalendarView(context: Context, attrs: AttributeSet? = null, defStyleA
             setAccentColorStateList(colorStateList)
             notifySettingsChanged()
         }
+    }
+
+    /**
+     * Sets the first day of week
+     */
+    fun setFirstDayOfWeek(weekDay: WeekDay) {
+        settings.apply {
+            firstDayOfWeek = weekDay
+            notifySettingsChanged()
+        }
+    }
+
+    private fun setFirstDayOfWeek(n: Int) {
+        setFirstDayOfWeek(WeekDay.fromOrdinal(n))
     }
 
     private inner class Adapter() : PagerAdapter() {

--- a/library/src/main/kotlin/jp/co/recruit_mp/android/lightcalendarview/WeekDay.kt
+++ b/library/src/main/kotlin/jp/co/recruit_mp/android/lightcalendarview/WeekDay.kt
@@ -40,7 +40,10 @@ enum class WeekDay {
          *
          * @param n number of times to slide elements
          */
-        fun getPermutation(n: Int) = values().let { it.slice((0..it.size - 1).map { i -> (i + n) % it.size }) }
+        fun getPermutation(n: Int): List<WeekDay> = values().let {
+            val indices = it.size.let { size -> (0..size - 1).map { i -> (i + n) % size } }
+            return it.slice(indices)
+        }
     }
 
     fun getShortLabel(context: Context): String = context.getStringArray(R.array.week_days_short)[ordinal]

--- a/library/src/main/kotlin/jp/co/recruit_mp/android/lightcalendarview/WeekDay.kt
+++ b/library/src/main/kotlin/jp/co/recruit_mp/android/lightcalendarview/WeekDay.kt
@@ -34,9 +34,15 @@ enum class WeekDay {
     companion object {
         val ordinals = values()
         fun fromOrdinal(ordinal: Int) = ordinals[ordinal]
+
+        /**
+         * Returns the rearranged WeekDay values by sliding elements by n times
+         *
+         * @param n number of times to slide elements
+         */
+        fun getPermutation(n: Int) = values().let { it.slice((0..it.size - 1).map { i -> (i + n) % it.size }) }
     }
 
     fun getShortLabel(context: Context): String = context.getStringArray(R.array.week_days_short)[ordinal]
     fun getLabel(context: Context): String = context.getStringArray(R.array.week_days_full)[ordinal]
-
 }

--- a/library/src/main/kotlin/jp/co/recruit_mp/android/lightcalendarview/WeekDayLayout.kt
+++ b/library/src/main/kotlin/jp/co/recruit_mp/android/lightcalendarview/WeekDayLayout.kt
@@ -33,7 +33,7 @@ class WeekDayLayout(context: Context, settings: CalendarSettings) : CellLayout(c
     override val colNum: Int
         get() = DEFAULT_DAYS_IN_WEEK
 
-    var weekDayOffset: Int = -1
+    var dayOfWeekOffset: Int = -1
 
     init {
         updateLayout()
@@ -54,8 +54,8 @@ class WeekDayLayout(context: Context, settings: CalendarSettings) : CellLayout(c
     }
 
     private fun updateLayout() {
-        if (weekDayOffset != settings.weekDayOffset) {
-            weekDayOffset = settings.weekDayOffset
+        if (dayOfWeekOffset != settings.dayOfWeekOffset) {
+            dayOfWeekOffset = settings.dayOfWeekOffset
 
             // remove all children
             removeAllViews()
@@ -67,7 +67,7 @@ class WeekDayLayout(context: Context, settings: CalendarSettings) : CellLayout(c
 
     private fun populateViews() {
         // add WeekDayViews in 7x1 grid
-        WeekDay.getPermutation(weekDayOffset).forEach { weekDay ->
+        WeekDay.getPermutation(dayOfWeekOffset).forEach { weekDay ->
             addView(WeekDayView(context, settings, weekDay))
         }
     }

--- a/library/src/main/kotlin/jp/co/recruit_mp/android/lightcalendarview/WeekDayLayout.kt
+++ b/library/src/main/kotlin/jp/co/recruit_mp/android/lightcalendarview/WeekDayLayout.kt
@@ -17,6 +17,7 @@
 package jp.co.recruit_mp.android.lightcalendarview
 
 import android.content.Context
+import java.util.*
 
 /**
  * 月カレンダー内の曜日ラベルを表示する {@link ViewGroup}
@@ -32,9 +33,39 @@ class WeekDayLayout(context: Context, settings: CalendarSettings) : CellLayout(c
     override val colNum: Int
         get() = DEFAULT_DAYS_IN_WEEK
 
-    init {
-        val weekDayOffset = WeekDay.values().indexOf(settings.firstDayOfWeek)
+    var weekDayOffset: Int = -1
 
+    init {
+        updateLayout()
+    }
+
+    private val observer = Observer { observable, any ->
+        updateLayout()
+    }
+
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+        settings.addObserver(observer)
+    }
+
+    override fun onDetachedFromWindow() {
+        settings.deleteObserver(observer)
+        super.onDetachedFromWindow()
+    }
+
+    private fun updateLayout() {
+        if (weekDayOffset != settings.weekDayOffset) {
+            weekDayOffset = settings.weekDayOffset
+
+            // remove all children
+            removeAllViews()
+
+            // populate children
+            populateViews()
+        }
+    }
+
+    private fun populateViews() {
         // add WeekDayViews in 7x1 grid
         WeekDay.getPermutation(weekDayOffset).forEach { weekDay ->
             addView(WeekDayView(context, settings, weekDay))

--- a/library/src/main/kotlin/jp/co/recruit_mp/android/lightcalendarview/WeekDayLayout.kt
+++ b/library/src/main/kotlin/jp/co/recruit_mp/android/lightcalendarview/WeekDayLayout.kt
@@ -33,10 +33,11 @@ class WeekDayLayout(context: Context, settings: CalendarSettings) : CellLayout(c
         get() = DEFAULT_DAYS_IN_WEEK
 
     init {
-        // 7 x 1 マスの WeekDayView を追加する
-        WeekDay.values().forEach { weekDay ->
+        val weekDayOffset = WeekDay.values().indexOf(settings.firstDayOfWeek)
+
+        // add WeekDayViews in 7x1 grid
+        WeekDay.getPermutation(weekDayOffset).forEach { weekDay ->
             addView(WeekDayView(context, settings, weekDay))
         }
     }
-
 }

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -6,5 +6,6 @@
         <attr name="lcv_textColor" format="reference|color" />
         <attr name="lcv_selectionColor" format="reference|color" />
         <attr name="lcv_accentColor" format="reference|color" />
+        <attr name="lcv_firstDayOfWeek" format="integer" />
     </declare-styleable>
 </resources>

--- a/library/src/main/res/values/integers.xml
+++ b/library/src/main/res/values/integers.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <integer name="lcv_sunday">0</integer>
+    <integer name="lcv_monday">1</integer>
+    <integer name="lcv_tuesday">2</integer>
+    <integer name="lcv_wednesday">3</integer>
+    <integer name="lcv_thurday">4</integer>
+    <integer name="lcv_friday">5</integer>
+    <integer name="lcv_saturday">6</integer>
+</resources>

--- a/sample/src/main/kotlin/jp/co/recruit_mp/android/lightcalendarview/sample/MainActivity.kt
+++ b/sample/src/main/kotlin/jp/co/recruit_mp/android/lightcalendarview/sample/MainActivity.kt
@@ -4,13 +4,10 @@ import android.os.Bundle
 import android.os.Handler
 import android.support.v7.app.AppCompatActivity
 import android.util.Log
-import android.view.Menu
-import android.widget.Button
 import jp.co.recruit_mp.android.lightcalendarview.LightCalendarView
 import jp.co.recruit_mp.android.lightcalendarview.MonthView
 import jp.co.recruit_mp.android.lightcalendarview.accent.Accent
 import jp.co.recruit_mp.android.lightcalendarview.accent.DotAccent
-import java.text.DateFormat
 import java.text.SimpleDateFormat
 import java.util.*
 
@@ -68,6 +65,5 @@ class MainActivity : AppCompatActivity() {
         supportActionBar?.apply {
             title = formatter.format(calendarView.let { it.getDateForPosition(it.currentItem) })
         }
-
     }
 }

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -27,7 +27,8 @@
                 app:lcv_dayTextSize="18sp"
                 app:lcv_textColor="@color/calendar_day_text"
                 app:lcv_selectionColor="@color/calendar_selection"
-                app:lcv_accentColor="@color/calendar_accent"/>
+                app:lcv_accentColor="@color/calendar_accent"
+                app:lcv_firstDayOfWeek="0"/>
 
         </LinearLayout>
     </ScrollView>

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -28,7 +28,7 @@
                 app:lcv_textColor="@color/calendar_day_text"
                 app:lcv_selectionColor="@color/calendar_selection"
                 app:lcv_accentColor="@color/calendar_accent"
-                app:lcv_firstDayOfWeek="0"/>
+                app:lcv_firstDayOfWeek="@integer/lcv_monday"/>
 
         </LinearLayout>
     </ScrollView>


### PR DESCRIPTION
## Overview
Adding a feature to change first day of the week (e.g. Sunday, Monday, etc...)

## References
* [Issue #9](https://github.com/recruit-mp/LightCalendarView/issues/9)

## Technical Changes
* added the method `LightCalendarView#setFirstDayOfWeek(weekDay: WeekDay)`
* added `lcv_firstDayOfWeek` to the layout parameters
* modified `WeekDayLayout` and `DayLayout` to rearrange child views in the correct order
* added `val firstDayOfWeek: WeekDay` setting to `CalendarSettings`

## Remaining Tasks
* [x] update README.md

## Screenshot
![screenshot_1481423037](https://cloud.githubusercontent.com/assets/21093614/21077621/e24e683e-bf94-11e6-9f0f-1b72fc22f65b.png)

## Reviewer
* @amyu
