### PR TITLE
[WIP] Adding feature to set the text color of each day of the week

### DIFF
--- a/library/src/main/kotlin/jp/co/recruit_mp/android/lightcalendarview/CalendarSettings.kt
+++ b/library/src/main/kotlin/jp/co/recruit_mp/android/lightcalendarview/CalendarSettings.kt
@@ -51,6 +51,14 @@ class CalendarSettings(private val context: Context) : ObservableSettings() {
                 defaultTextPaints.values.forEach { it.textSize = value }
             }
 
+        private val textFilterColorMap: MutableMap<WeekDay, Int?> = WeekDay.values().map {
+            it to when (it) {
+                WeekDay.SUNDAY -> context.getColorCompat(R.color.light_calendar_view__week_day_sunday_text_color)
+                WeekDay.SATURDAY -> context.getColorCompat(R.color.light_calendar_view__week_day_saturday_text_color)
+                else -> null
+            }
+        }.toMutableMap()
+
         // ------------- Base --------------------------------------------------------------------------------------
         var basePaint: Paint = Paint().textSize(this@WeekDayView.textSize).color(this@WeekDayView.textColor).typeface(Typeface.DEFAULT).isAntiAlias(true)
             set(value) {
@@ -65,16 +73,17 @@ class CalendarSettings(private val context: Context) : ObservableSettings() {
         internal var defaultTextPaints: Map<WeekDay, Paint> = initializedDefaultTextPaints()
 
         private fun initializedDefaultTextPaints() = WeekDay.values().map {
-            it to basePaint.copy().colorFilter(when (it) {
-                WeekDay.SUNDAY -> PorterDuffColorFilter(context.getColorCompat(R.color.light_calendar_view__week_day_sunday_text_color), PorterDuff.Mode.SRC_ATOP)
-                WeekDay.SATURDAY -> PorterDuffColorFilter(context.getColorCompat(R.color.light_calendar_view__week_day_saturday_text_color), PorterDuff.Mode.SRC_ATOP)
-                else -> null
-            })
+            it to basePaint.copy().colorFilter(textFilterColorMap[it]?.let { color -> PorterDuffColorFilter(color, PorterDuff.Mode.SRC_ATOP) } ?: null)
         }.toMap()
         // ---------------------------------------------------------------------------------------------------------
 
         internal fun setTextColorStateList(colorStateList: ColorStateList) {
             textColor = colorStateList.getColorForState(State.DEFAULT.value, textColor)
+        }
+
+        internal fun setTextFilterColor(weekDay: WeekDay, color: Int?) {
+            textFilterColorMap[weekDay] = color
+            defaultTextPaints[weekDay]?.colorFilter(textFilterColorMap[weekDay]?.let { color -> PorterDuffColorFilter(color, PorterDuff.Mode.SRC_ATOP) } ?: null)
         }
     }
 
@@ -100,6 +109,14 @@ class CalendarSettings(private val context: Context) : ObservableSettings() {
                 selectedTextPaint.textSize(value)
                 selectedTodayTextPaint.textSize(value)
             }
+
+        private val textFilterColorMap: MutableMap<WeekDay, Int?> = WeekDay.values().map {
+            it to when (it) {
+                WeekDay.SUNDAY -> context.getColorCompat(R.color.light_calendar_view__day_sunday_text_color)
+                WeekDay.SATURDAY -> context.getColorCompat(R.color.light_calendar_view__day_saturday_text_color)
+                else -> null
+            }
+        }.toMutableMap()
 
         // ------------- Base --------------------------------------------------------------------------------------
         var baseCirclePaint: Paint = Paint().isAntiAlias(true).style(Paint.Style.FILL)
@@ -148,11 +165,7 @@ class CalendarSettings(private val context: Context) : ObservableSettings() {
         internal var selectedTodayTextPaint: Paint = initializedSelectedTodayTextPaint()
 
         private fun initializedDefaultTextPaints() = WeekDay.values().map {
-            it to baseTextPaint.copy().colorFilter(when (it) {
-                WeekDay.SUNDAY -> PorterDuffColorFilter(context.getColorCompat(R.color.light_calendar_view__day_sunday_text_color), PorterDuff.Mode.SRC_ATOP)
-                WeekDay.SATURDAY -> PorterDuffColorFilter(context.getColorCompat(R.color.light_calendar_view__day_saturday_text_color), PorterDuff.Mode.SRC_ATOP)
-                else -> null
-            })
+            it to baseTextPaint.copy().colorFilter(textFilterColorMap[it]?.let { color -> PorterDuffColorFilter(color, PorterDuff.Mode.SRC_ATOP) } ?: null)
         }.toMap()
 
         private fun initializedTodayTextPaint() = baseTextPaint.copy().color(context.getStyledColor(android.R.attr.textColorPrimary, context.getColorCompat(R.color.light_calendar_view__day_today_text_color)))
@@ -182,6 +195,11 @@ class CalendarSettings(private val context: Context) : ObservableSettings() {
             todayTextPaint.color(colorStateList, State.TODAY)
             selectedTextPaint.color(colorStateList, State.SELECTED)
             selectedTodayTextPaint.color(colorStateList, State.SELECTED_TODAY)
+        }
+
+        internal fun setTextFilterColor(weekDay: WeekDay, color: Int?) {
+            textFilterColorMap[weekDay] = color
+            defaultTextPaints[weekDay]?.colorFilter(textFilterColorMap[weekDay]?.let { color -> PorterDuffColorFilter(color, PorterDuff.Mode.SRC_ATOP) } ?: null)
         }
 
         internal fun setAccentColorStateList(colorStateList: ColorStateList) {
@@ -233,4 +251,7 @@ class CalendarSettings(private val context: Context) : ObservableSettings() {
      * {@see http://stackoverflow.com/questions/12155553/android-typeface-not-copied-into-new-paint}
      */
     private fun Paint.copy(): Paint = Paint(this).apply { typeface = this@copy.typeface }
+
+    /** Converts a map to a mutable map */
+    private fun <K, V> Iterable<Pair<K, V>>.toMutableMap(): MutableMap<K, V> = mutableMapOf<K, V>().apply { putAll(this@toMutableMap) }
 }

--- a/library/src/main/kotlin/jp/co/recruit_mp/android/lightcalendarview/LightCalendarView.kt
+++ b/library/src/main/kotlin/jp/co/recruit_mp/android/lightcalendarview/LightCalendarView.kt
@@ -214,6 +214,26 @@ class LightCalendarView(context: Context, attrs: AttributeSet? = null, defStyleA
         }
     }
 
+    /**
+     * Sets color of a weekday of the week
+     */
+    fun setWeekDayFilterColor(weekDay: WeekDay, color: Int?) {
+        settings.weekDayView.apply {
+            setTextFilterColor(weekDay, color)
+            notifySettingsChanged()
+        }
+    }
+
+    /**
+     * Sets color of a day of the week
+     */
+    fun setDayFilterColor(weekDay: WeekDay, color: Int?) {
+        settings.dayView.apply {
+            setTextFilterColor(weekDay, color)
+            notifySettingsChanged()
+        }
+    }
+
     private inner class Adapter() : PagerAdapter() {
         override fun instantiateItem(container: ViewGroup?, position: Int): View {
             val view = MonthView(context, settings, getDateForPosition(position)).apply {


### PR DESCRIPTION
## Overview
Adding feature to set the text color of each day of the week (e.g. Sunday, Monday, etc...)

## Technical Changes
* added methods `LightCalendarView#setWeekDayFilterColor(weekDay: WeekDay, color: Int?)` and `LightCalendarView#setDayFilterColor(weekDay: WeekDay, color: Int?)`
* added `val textFilterColorMap: MutableMap<WeekDay, Int?>` setting to `CalendarSettings.WeekDayView` and `CalendarSettings.DayView`

## Remaining Tasks
* [ ] add layout attributes
* [ ] update README.md

## Screenshot
![screenshot_1481609325](https://cloud.githubusercontent.com/assets/21093614/21129607/12ffda50-c146-11e6-99a2-5b6e68d982d0.png)

## Reviewer
@amyu
